### PR TITLE
Return HTTP 500 instead of 200 for out-of-airtime response

### DIFF
--- a/airtime_service/api.py
+++ b/airtime_service/api.py
@@ -48,8 +48,7 @@ class AirtimeServiceApp(object):
             voucher = yield pool.issue_voucher(
                 operator, params['denomination'], audit_params)
         except NoVoucherAvailable:
-            # This is a normal condition, so we still return a 200 OK.
-            raise APIError('No voucher available.', 200)
+            raise APIError('No voucher available.', 500)
         finally:
             yield conn.close()
 

--- a/airtime_service/tests/test_api.py
+++ b/airtime_service/tests/test_api.py
@@ -216,7 +216,8 @@ class TestAirtimeServiceApp(TestCase):
     @inlineCallbacks
     def test_issue_no_voucher(self):
         yield populate_pool(self.pool, ['Tank'], ['red'], [0])
-        rsp = yield self.client.put_issue('req-0', 'Tank', 'blue')
+        rsp = yield self.client.put_issue(
+            'req-0', 'Tank', 'blue', expected_code=500)
         assert rsp == {
             'request_id': 'req-0',
             'error': 'No voucher available.',


### PR DESCRIPTION
From https://github.com/praekelt/airtime-service/issues/4#issuecomment-28696256
