### PR TITLE
Initial review.

### DIFF
--- a/airtime_service/models.py
+++ b/airtime_service/models.py
@@ -91,15 +91,15 @@ class VoucherPool(PrefixedTableCollection):
         transaction_id = audit_params['transaction_id']
         user_id = audit_params['user_id']
         return self.execute_query(
-            self.audit.insert().values(**{
-                'request_id': request_id,
-                'transaction_id': transaction_id,
-                'user_id': user_id,
-                'request_data': json.dumps(req_data),
-                'response_data': json.dumps(resp_data),
-                'error': error,
-                'created_at': datetime.utcnow(),
-            }))
+            self.audit.insert().values(
+                request_id=request_id,
+                transaction_id=transaction_id,
+                user_id=user_id,
+                request_data=json.dumps(req_data),
+                response_data=json.dumps(resp_data),
+                error=error,
+                created_at=datetime.utcnow(),
+            ))
 
     @inlineCallbacks
     def _get_previous_request(self, audit_params, req_data):
@@ -146,11 +146,11 @@ class VoucherPool(PrefixedTableCollection):
                 raise AuditMismatch(row['content_md5'])
 
         yield self.execute_query(
-            self.import_audit.insert().values(**{
-                'request_id': request_id,
-                'content_md5': content_md5,
-                'created_at': datetime.utcnow(),
-            }))
+            self.import_audit.insert().values(
+                request_id=request_id,
+                content_md5=content_md5,
+                created_at=datetime.utcnow(),
+            ))
 
         # NOTE: We're assuming that this will be fast enough. If it isn't,
         # we'll need to make a database-specific plan of some kind.
@@ -314,10 +314,10 @@ class VoucherPool(PrefixedTableCollection):
             if voucher is None:
                 break
             yield self.execute_query(
-                self.exported_vouchers.insert().values(**{
-                    'request_id': request_id,
-                    'voucher_id': voucher['id'],
-                }))
+                self.exported_vouchers.insert().values(
+                    request_id=request_id,
+                    voucher_id=voucher['id'],
+                ))
             vouchers.append(voucher)
 
         if (count is not None) and (count > len(vouchers)):
@@ -361,12 +361,12 @@ class VoucherPool(PrefixedTableCollection):
             response['warnings'].extend(warnings)
 
         yield self.execute_query(
-            self.export_audit.insert().values(**{
-                'request_id': request_id,
-                'request_data': json.dumps(request_data),
-                'warnings': json.dumps(response['warnings']),
-                'created_at': datetime.utcnow(),
-            }))
+            self.export_audit.insert().values(
+                request_id=request_id,
+                request_data=json.dumps(request_data),
+                warnings=json.dumps(response['warnings']),
+                created_at=datetime.utcnow(),
+            ))
 
         yield trx.commit()
         returnValue(response)

--- a/airtime_service/models.py
+++ b/airtime_service/models.py
@@ -31,10 +31,10 @@ class NoVoucherAvailable(VoucherError):
 class VoucherPool(PrefixedTableCollection):
     vouchers = make_table(
         Column("id", Integer(), primary_key=True),
-        Column("operator", String(), nullable=False),
-        Column("denomination", String(), nullable=False),
-        Column("voucher", String(), nullable=False),
-        Column("used", Boolean(), default=False),
+        Column("operator", String(), nullable=False, index=True),
+        Column("denomination", String(), nullable=False, index=True),
+        Column("voucher", String(), nullable=False, index=True),
+        Column("used", Boolean(), default=False, index=True),
         Column("created_at", DateTime(timezone=True)),
         Column("modified_at", DateTime(timezone=True)),
         Column("reason", String(), default=None),

--- a/airtime_service/service.py
+++ b/airtime_service/service.py
@@ -11,7 +11,6 @@ DEFAULT_PORT = '8080'
 
 class Options(usage.Options):
     """Command line args when run as a twistd plugin"""
-    # TODO other args
     optParameters = [["port", "p", DEFAULT_PORT,
                       "Port number for airtime-service to listen on"],
                      ["database-connection-string", "d", None,


### PR DESCRIPTION
This is just to gather up general discussion from the initial review. Things that require code to be written should be spun out into separate tickets.

Outstanding discussion points:
- [x] try-finally around VoucherPool creation
- [x] issue_voucher return code when no voucher is available
- [x] voucher.reason not accessible via the API
- [x] unnecessary use of *\* in `_audit_request`
- [x] separate API method for voucher pool creation
- [x] better CSV validation and cleaning
- [x] remove TODO about extra service options
- [x] indexes for voucher table `operator`, `denomination` and `used` fields
- [x] pep8 fix and `pytest-pep8`
- [x] more unnecessary kwargs usage
